### PR TITLE
V5 OoT scene lighting

### DIFF
--- a/fast64_internal/f3d/f3d_material.py
+++ b/fast64_internal/f3d/f3d_material.py
@@ -3339,12 +3339,36 @@ class F3DRenderSettingsPanel(bpy.types.Panel):
                     gameSettingsBox.prop(renderSettings, "sm64Area")
 
                 case "OOT":
-                    # TODO: OOT scene preview options
-                    # if renderSettings.ootSceneObject is not None:
-                    #     gameSettingsBox.prop(renderSettings, 'useObjectRenderPreview', text="Use Scene for Preview")
-                    gameSettingsBox.label(text="Preview not yet available for OOT Scenes.")
+                    if renderSettings.ootSceneObject is not None:
+                        gameSettingsBox.prop(renderSettings, "useObjectRenderPreview", text="Use Scene for Preview")
 
-                    # gameSettingsBox.prop(renderSettings, 'ootSceneObject')
+                    gameSettingsBox.prop(renderSettings, "ootSceneObject")
+                    
+                    if renderSettings.ootSceneObject is not None:
+                        b = gameSettingsBox.box().column()
+                        b.prop(renderSettings, "ootSceneHeader")
+                        header = ootGetSceneOrRoomHeader(
+                            renderSettings.ootSceneObject,
+                            renderSettings.ootSceneHeader,
+                            False,
+                        )
+                        if header is None:
+                            b.label(text = "Scene header does not exist.", icon="QUESTION")
+                        else:
+                            numLightsNeeded = 1
+                            if header.skyboxLighting == "Custom":
+                                r = b.row()
+                                r.prop(renderSettings, "ootForceTimeOfDay")
+                                if renderSettings.ootForceTimeOfDay:
+                                    r.label(text = "Light Index sets first of four lights.", icon="INFO")
+                                    numLightsNeeded = 4
+                            if header.skyboxLighting != "0x00":
+                                b.prop(renderSettings, "ootLightIdx")
+                                if renderSettings.ootLightIdx + numLightsNeeded > len(header.lightList):
+                                    b.label(text = "Light does not exist.", icon="QUESTION")
+                            if header.skyboxLighting == "0x00" or (
+                                header.skyboxLighting == "Custom" and renderSettings.ootForceTimeOfDay):
+                                b.prop(renderSettings, "ootTime")
                 case _:
                     pass
 

--- a/fast64_internal/f3d/f3d_material.py
+++ b/fast64_internal/f3d/f3d_material.py
@@ -3345,30 +3345,31 @@ class F3DRenderSettingsPanel(bpy.types.Panel):
                     gameSettingsBox.prop(renderSettings, "ootSceneObject")
                     
                     if renderSettings.ootSceneObject is not None:
-                        b = gameSettingsBox.box().column()
-                        b.prop(renderSettings, "ootSceneHeader")
+                        b = gameSettingsBox.column()
+                        r = b.row().split(factor=0.4)
+                        r.prop(renderSettings, "ootSceneHeader")
                         header = ootGetSceneOrRoomHeader(
                             renderSettings.ootSceneObject,
                             renderSettings.ootSceneHeader,
                             False,
                         )
                         if header is None:
-                            b.label(text = "Scene header does not exist.", icon="QUESTION")
+                            r.label(text = "Header does not exist.", icon="QUESTION")
                         else:
                             numLightsNeeded = 1
                             if header.skyboxLighting == "Custom":
-                                r = b.row()
-                                r.prop(renderSettings, "ootForceTimeOfDay")
+                                r2 = b.row()
+                                r2.prop(renderSettings, "ootForceTimeOfDay")
                                 if renderSettings.ootForceTimeOfDay:
-                                    r.label(text = "Light Index sets first of four lights.", icon="INFO")
+                                    r2.label(text = "Light Index sets first of four lights.", icon="INFO")
                                     numLightsNeeded = 4
                             if header.skyboxLighting != "0x00":
-                                b.prop(renderSettings, "ootLightIdx")
+                                r.prop(renderSettings, "ootLightIdx")
                                 if renderSettings.ootLightIdx + numLightsNeeded > len(header.lightList):
                                     b.label(text = "Light does not exist.", icon="QUESTION")
                             if header.skyboxLighting == "0x00" or (
                                 header.skyboxLighting == "Custom" and renderSettings.ootForceTimeOfDay):
-                                b.prop(renderSettings, "ootTime")
+                                r.prop(renderSettings, "ootTime")
                 case _:
                     pass
 

--- a/fast64_internal/f3d/f3d_writer.py
+++ b/fast64_internal/f3d/f3d_writer.py
@@ -2374,43 +2374,13 @@ def saveLightsDefinition(fModel, fMaterial, material, lightsName):
 
 
 def addLightDefinition(mat, f3d_light, fLights):
+    lightObj = lightDataToObj(f3d_light)
     fLights.l.append(
         Light(
             exportColor(f3d_light.color),
-            getLightRotation(f3d_light),
+            normToSigned8Vector(getObjDirectionVec(lightObj, True)),
         )
     )
-
-
-def scaleToU8(val):
-    return min(int(round(val * 0xFF)), 255)
-
-
-def exportColor(lightColor):
-    return [scaleToU8(value) for value in gammaCorrect(lightColor)]
-
-
-def getLightRotation(lightData):
-    lightObj = None
-    for obj in bpy.context.scene.objects:
-        if obj.data == lightData:
-            lightObj = obj
-            break
-    if lightObj is None:
-        raise PluginError("A material is referencing a light that is no longer in the scene (i.e. has been deleted).")
-
-    return getObjDirection(lightObj)
-
-
-def getObjDirection(obj):
-    spaceRot = mathutils.Euler((-pi / 2, 0, 0)).to_quaternion()
-    rotation = spaceRot @ getObjectQuaternion(obj)
-    normal = (rotation @ mathutils.Vector((0, 0, 1))).normalized()
-    return normToSigned8Vector(normal)
-
-
-def normToSigned8Vector(normal):
-    return [int.from_bytes(int(value * 127).to_bytes(1, "big", signed=True), "big") for value in normal]
 
 
 def saveBitGeoF3DEX2(value, defaultValue, flagName, geo, matWriteMethod):

--- a/fast64_internal/oot/oot_level_writer.py
+++ b/fast64_internal/oot/oot_level_writer.py
@@ -256,24 +256,8 @@ def getExitData(exitProp):
 def getLightData(lightProp):
     light = OOTLight()
     light.ambient = exportColor(lightProp.ambient)
-    if lightProp.useCustomDiffuse0:
-        if lightProp.diffuse0Custom is None:
-            raise PluginError("Error: Diffuse 0 light object not set in a scene lighting property.")
-        light.diffuse0 = exportColor(lightProp.diffuse0Custom.color)
-        light.diffuseDir0 = getLightRotation(lightProp.diffuse0Custom)
-    else:
-        light.diffuse0 = exportColor(lightProp.diffuse0)
-        light.diffuseDir0 = [0x49, 0x49, 0x49]
-
-    if lightProp.useCustomDiffuse1:
-        if lightProp.diffuse1Custom is None:
-            raise PluginError("Error: Diffuse 1 light object not set in a scene lighting property.")
-        light.diffuse1 = exportColor(lightProp.diffuse1Custom.color)
-        light.diffuseDir1 = getLightRotation(lightProp.diffuse1Custom)
-    else:
-        light.diffuse1 = exportColor(lightProp.diffuse1)
-        light.diffuseDir1 = [0xB7, 0xB7, 0xB7]
-
+    light.diffuse0, light.diffuseDir0 = ootGetBaseOrCustomLight(lightProp, 0, True, True)
+    light.diffuse1, light.diffuseDir1 = ootGetBaseOrCustomLight(lightProp, 1, True, True)
     light.fogColor = exportColor(lightProp.fogColor)
     light.fogNear = lightProp.fogNear
     light.transitionSpeed = lightProp.transitionSpeed

--- a/fast64_internal/oot/oot_scene_room.py
+++ b/fast64_internal/oot/oot_scene_room.py
@@ -32,18 +32,7 @@ class OOT_SearchMusicSeqEnumOperator(bpy.types.Operator):
 	objName : bpy.props.StringProperty()
 
 	def execute(self, context):
-		obj = bpy.data.objects[self.objName]
-		if self.headerIndex == 0:
-			sceneHeader = obj.ootSceneHeader
-		elif self.headerIndex == 1:
-			sceneHeader = obj.ootAlternateSceneHeaders.childNightHeader
-		elif self.headerIndex == 2:
-			sceneHeader = obj.ootAlternateSceneHeaders.adultDayHeader
-		elif self.headerIndex == 3:
-			sceneHeader = obj.ootAlternateSceneHeaders.adultNightHeader
-		else:
-			sceneHeader = obj.ootAlternateSceneHeaders.cutsceneHeaders[self.headerIndex - 4]
-
+		sceneHeader = ootGetSceneOrRoomHeader(bpy.data.objects[self.objName], self.headerIndex, False)
 		sceneHeader.musicSeq = self.ootMusicSeq
 		bpy.context.region.tag_redraw()
 		self.report({'INFO'}, "Selected: " + self.ootMusicSeq)
@@ -65,18 +54,7 @@ class OOT_SearchObjectEnumOperator(bpy.types.Operator):
 	objName : bpy.props.StringProperty()
 
 	def execute(self, context):
-		obj = bpy.data.objects[self.objName]
-		if self.headerIndex == 0:
-			roomHeader = obj.ootRoomHeader
-		elif self.headerIndex == 1:
-			roomHeader = obj.ootAlternateRoomHeaders.childNightHeader
-		elif self.headerIndex == 2:
-			roomHeader = obj.ootAlternateRoomHeaders.adultDayHeader
-		elif self.headerIndex == 3:
-			roomHeader = obj.ootAlternateRoomHeaders.adultNightHeader
-		else:
-			roomHeader = obj.ootAlternateRoomHeaders.cutsceneHeaders[self.headerIndex - 4]
-
+		roomHeader = ootGetSceneOrRoomHeader(bpy.data.objects[self.objName], self.headerIndex, True)
 		roomHeader.objectList[self.index].objectID = self.ootObjectID
 		bpy.context.region.tag_redraw()
 		self.report({'INFO'}, "Selected: " + self.ootObjectID)

--- a/fast64_internal/oot/oot_scene_room.py
+++ b/fast64_internal/oot/oot_scene_room.py
@@ -10,6 +10,10 @@ from ..f3d.f3d_gbi import *
 from .oot_actor import *
 #from .oot_collision import *
 from .oot_cutscene import *
+from ..render_settings import on_update_oot_render_settings
+
+def onUpdateOoTLighting(self, context: bpy.types.Context):
+	on_update_oot_render_settings(self, context)
 
 class OOTSceneProperties(bpy.types.PropertyGroup):
 	write_dummy_room_list: bpy.props.BoolProperty(
@@ -164,17 +168,17 @@ def drawObjectProperty(layout, objectProp, headerIndex, index, objName):
 		objSearch.index = index
 
 class OOTLightProperty(bpy.types.PropertyGroup):
-	ambient : bpy.props.FloatVectorProperty(name = "Ambient Color", size = 4, min = 0, max = 1, default = (70/255, 40/255, 57/255 ,1), subtype = 'COLOR')
-	useCustomDiffuse0 : bpy.props.BoolProperty(name = 'Use Custom Diffuse 0 Light Object')
-	useCustomDiffuse1 : bpy.props.BoolProperty(name = 'Use Custom Diffuse 1 Light Object')
-	diffuse0 :  bpy.props.FloatVectorProperty(name = "", size = 4, min = 0, max = 1, default = (180/255, 154/255, 138/255 ,1), subtype = 'COLOR')
-	diffuse1 :  bpy.props.FloatVectorProperty(name = "", size = 4, min = 0, max = 1, default = (20/255, 20/255, 60/255 ,1), subtype = 'COLOR')
-	diffuse0Custom : bpy.props.PointerProperty(name = "Diffuse 0", type = bpy.types.Light)
-	diffuse1Custom : bpy.props.PointerProperty(name = "Diffuse 1", type = bpy.types.Light)
-	fogColor : bpy.props.FloatVectorProperty(name = "", size = 4, min = 0, max = 1, default = (140/255, 120/255, 110/255 ,1), subtype = 'COLOR')
-	fogNear : bpy.props.IntProperty(name = "", default = 993, min = 0, max = 2**10 - 1)
-	transitionSpeed : bpy.props.IntProperty(name = "", default = 1, min = 0, max = 63)
-	fogFar : bpy.props.IntProperty(name = "", default = 0x3200, min = 0, max = 2**16 - 1)
+	ambient : bpy.props.FloatVectorProperty(name = "Ambient Color", size = 4, min = 0, max = 1, default = (70/255, 40/255, 57/255 ,1), subtype = 'COLOR', update = onUpdateOoTLighting)
+	useCustomDiffuse0 : bpy.props.BoolProperty(name = 'Use Custom Diffuse 0 Light Object', update = onUpdateOoTLighting)
+	useCustomDiffuse1 : bpy.props.BoolProperty(name = 'Use Custom Diffuse 1 Light Object', update = onUpdateOoTLighting)
+	diffuse0 :  bpy.props.FloatVectorProperty(name = "", size = 4, min = 0, max = 1, default = (180/255, 154/255, 138/255 ,1), subtype = 'COLOR', update = onUpdateOoTLighting)
+	diffuse1 :  bpy.props.FloatVectorProperty(name = "", size = 4, min = 0, max = 1, default = (20/255, 20/255, 60/255 ,1), subtype = 'COLOR', update = onUpdateOoTLighting)
+	diffuse0Custom : bpy.props.PointerProperty(name = "Diffuse 0", type = bpy.types.Light, update = onUpdateOoTLighting)
+	diffuse1Custom : bpy.props.PointerProperty(name = "Diffuse 1", type = bpy.types.Light, update = onUpdateOoTLighting)
+	fogColor : bpy.props.FloatVectorProperty(name = "", size = 4, min = 0, max = 1, default = (140/255, 120/255, 110/255 ,1), subtype = 'COLOR', update = onUpdateOoTLighting)
+	fogNear : bpy.props.IntProperty(name = "", default = 993, min = 0, max = 2**10 - 1, update = onUpdateOoTLighting)
+	transitionSpeed : bpy.props.IntProperty(name = "", default = 1, min = 0, max = 63, update = onUpdateOoTLighting)
+	fogFar : bpy.props.IntProperty(name = "", default = 0x3200, min = 0, max = 2**16 - 1, update = onUpdateOoTLighting)
 	expandTab : bpy.props.BoolProperty(name = "Expand Tab")
 
 class OOTLightGroupProperty(bpy.types.PropertyGroup):
@@ -256,8 +260,8 @@ class OOTSceneHeaderProperty(bpy.types.PropertyGroup):
 	skyboxIDCustom : bpy.props.StringProperty(name = "Skybox ID", default = '0')
 	skyboxCloudiness : bpy.props.EnumProperty(name = "Cloudiness", items = ootEnumCloudiness, default = "0x00")
 	skyboxCloudinessCustom : bpy.props.StringProperty(name = "Cloudiness ID", default = '0x00')
-	skyboxLighting : bpy.props.EnumProperty(name = "Skybox Lighting", items = ootEnumSkyboxLighting, default = "0x00")
-	skyboxLightingCustom : bpy.props.StringProperty(name = "Skybox Lighting Custom", default = '0x00')
+	skyboxLighting : bpy.props.EnumProperty(name = "Skybox Lighting", items = ootEnumSkyboxLighting, default = "0x00", update = onUpdateOoTLighting)
+	skyboxLightingCustom : bpy.props.StringProperty(name = "Skybox Lighting Custom", default = '0x00', update = onUpdateOoTLighting)
 
 	mapLocation : bpy.props.EnumProperty(name = "Map Location", items = ootEnumMapLocation, default = "0x00")
 	mapLocationCustom : bpy.props.StringProperty(name = "Skybox Lighting Custom", default = '0x00')

--- a/fast64_internal/oot/oot_utility.py
+++ b/fast64_internal/oot/oot_utility.py
@@ -327,9 +327,11 @@ def getRoomObj(obj):
     else:
         return obj
 
+
 def checkEmptyName(name):
     if name == "":
         raise PluginError("No name entered for the exporter.")
+
 
 def ootGetObjectPath(isCustomExport, exportPath, folderName):
     if isCustomExport:

--- a/fast64_internal/oot/oot_utility.py
+++ b/fast64_internal/oot/oot_utility.py
@@ -327,11 +327,9 @@ def getRoomObj(obj):
     else:
         return obj
 
-
 def checkEmptyName(name):
     if name == "":
         raise PluginError("No name entered for the exporter.")
-
 
 def ootGetObjectPath(isCustomExport, exportPath, folderName):
     if isCustomExport:
@@ -448,32 +446,8 @@ def getCutsceneName(obj):
 
 
 def getCollectionFromIndex(obj, prop, subIndex, isRoom):
-    if not isRoom:
-        header0 = obj.ootSceneHeader
-        header1 = obj.ootAlternateSceneHeaders.childNightHeader
-        header2 = obj.ootAlternateSceneHeaders.adultDayHeader
-        header3 = obj.ootAlternateSceneHeaders.adultNightHeader
-        cutsceneHeaders = obj.ootAlternateSceneHeaders.cutsceneHeaders
-    else:
-        header0 = obj.ootRoomHeader
-        header1 = obj.ootAlternateRoomHeaders.childNightHeader
-        header2 = obj.ootAlternateRoomHeaders.adultDayHeader
-        header3 = obj.ootAlternateRoomHeaders.adultNightHeader
-        cutsceneHeaders = obj.ootAlternateRoomHeaders.cutsceneHeaders
-
-    if subIndex < 0:
-        raise PluginError("Alternate scene header index too low: " + str(subIndex))
-    elif subIndex == 0:
-        collection = getattr(header0, prop)
-    elif subIndex == 1:
-        collection = getattr(header1, prop)
-    elif subIndex == 2:
-        collection = getattr(header2, prop)
-    elif subIndex == 3:
-        collection = getattr(header3, prop)
-    else:
-        collection = getattr(cutsceneHeaders[subIndex - 4], prop)
-    return collection
+    header = ootGetSceneOrRoomHeader(obj, subIndex, isRoom)
+    return getattr(header, prop)
 
 
 # Operators cannot store mutable references (?), so to reuse PropertyCollection modification code we do this.

--- a/fast64_internal/render_settings.py
+++ b/fast64_internal/render_settings.py
@@ -158,3 +158,23 @@ class Fast64RenderSettings_Properties(bpy.types.PropertyGroup):
     ootSceneObject: bpy.props.PointerProperty(
         name="Scene Object", type=bpy.types.Object, update=on_update_oot_render_settings, poll=poll_oot_scene
     )
+    ootSceneHeader: bpy.props.IntProperty(
+        name="Header/Setup",
+        description="Scene header / setup to use lighting data from.",
+        min=0, soft_max=10, default=0
+    )
+    ootForceTimeOfDay: bpy.props.BoolProperty(
+        name="Force Time of Day",
+        description="Interpolate between four lights based on the time.",
+        default=False
+    )
+    ootLightIdx: bpy.props.IntProperty(
+        name="Light Index",
+        min=0, soft_max=10, default=0
+    )
+    ootTime: bpy.props.FloatProperty(
+        name="Time of Day (Hours)",
+        description="Time of day to emulate lighting conditions at, in hours.",
+        min=0.0, max=23.99, precision=2, subtype="TIME", unit="TIME"
+    )
+    

--- a/fast64_internal/render_settings.py
+++ b/fast64_internal/render_settings.py
@@ -78,6 +78,7 @@ def on_update_oot_render_settings(self, context: bpy.types.Context):
             -cost * 120.0 / 127.0,
             -cost *  20.0 / 127.0,
         )).normalized()
+        # TODO: Implement light1 into shader nodes
         # renderSettings.light1Direction = -renderSettings.lightDirection
         renderSettings.fogColor = interpColors(la.fogColor, lb.fogColor, fade)
         renderSettings.fogPreviewPosition = (

--- a/fast64_internal/render_settings.py
+++ b/fast64_internal/render_settings.py
@@ -1,6 +1,7 @@
 import bpy
 import mathutils
-from .utility import get_blender_to_game_scale, transform_mtx_blender_to_n64
+import math
+from .utility import *
 
 
 def on_update_sm64_render_settings(self, context: bpy.types.Context):
@@ -14,8 +15,73 @@ def on_update_sm64_render_settings(self, context: bpy.types.Context):
 
 
 def on_update_oot_render_settings(self, context: bpy.types.Context):
-    # TODO: Update render properties from selected OOTLightProperty
-    pass
+    renderSettings: "Fast64RenderSettings_Properties" = context.scene.fast64.renderSettings
+    if renderSettings.ootSceneObject is None or not renderSettings.useObjectRenderPreview:
+        return
+    header = ootGetSceneOrRoomHeader(
+        renderSettings.ootSceneObject,
+        renderSettings.ootSceneHeader,
+        False,
+    )
+    if header is None:
+        return
+    lMode = header.skyboxLighting
+    if lMode == "0x01" or (lMode == "Custom" and not renderSettings.ootForceTimeOfDay):
+        if renderSettings.ootLightIdx >= len(header.lightList):
+            return
+        l = header.lightList[renderSettings.ootLightIdx]
+        renderSettings.ambientColor = tuple(c for c in l.ambient)
+        col0, dir0 = ootGetBaseOrCustomLight(l, 0, False, False)
+        renderSettings.lightColor = tuple(c for c in col0)
+        renderSettings.lightDirection = tuple(d for d in dir0)
+        # col1, dir1 = ootGetBaseOrCustomLight(l, 1, False, False)
+        # renderSettings.light1Color = tuple(c for c in col1)
+        # renderSettings.light1Direction = tuple(d for d in dir1)
+        renderSettings.fogPreviewColor = tuple(c for c in l.fogColor)
+        renderSettings.fogPreviewPosition = (l.fogNear, l.fogFar)
+    else:
+        if header.skyboxLighting == "0x00":
+            tod = header.timeOfDayLights
+            lights = [tod.dawn, tod.day, tod.dusk, tod.night]
+        else:
+            if renderSettings.ootLightIdx + 4 > len(header.lightList):
+                return
+            lights = header.lightList[renderSettings.ootLightIdx:renderSettings.ootLightIdx+4]
+        assert len(lights) == 4
+        todTimes = [0.0, 4.0, 6.0, 8.0, 16.0, 17.0, 19.0, 24.0]
+        todSets  = [  3,   3,   0,   1,    1,    2,    3,    3]
+        t = renderSettings.ootTime
+        for i in range(len(todTimes) - 1):
+            assert t >= todTimes[i]
+            if t < todTimes[i+1]:
+                la, lb = lights[todSets[i]], lights[todSets[i+1]]
+                fade = (t - todTimes[i]) / (todTimes[i+1] - todTimes[i])
+                break
+        else:
+            raise PluginError("OoT time of day out of range")
+        def interpColors(cola, colb, fade):
+            cola = mathutils.Vector(tuple(c for c in cola))
+            colb = mathutils.Vector(tuple(c for c in colb))
+            return cola + (colb - cola) * fade
+        renderSettings.ambientColor = interpColors(la.ambient, lb.ambient, fade)
+        col0a, _ = ootGetBaseOrCustomLight(la, 0, False, False)
+        col0b, _ = ootGetBaseOrCustomLight(lb, 0, False, False)
+        renderSettings.lightColor = col0a + (col0b - col0a) * fade
+        # col1a, _ = ootGetBaseOrCustomLight(la, 1, False, False)
+        # col1b, _ = ootGetBaseOrCustomLight(lb, 1, False, False)
+        # renderSettings.light1Color = col1a * fa + col1b * fb
+        sint, cost = math.sin(math.tau * t / 24.0), math.cos(math.tau * t / 24.0)
+        renderSettings.lightDirection = mathutils.Vector((
+            sint * 120.0 / 127.0,
+            -cost * 120.0 / 127.0,
+            -cost *  20.0 / 127.0,
+        )).normalized()
+        # renderSettings.light1Direction = -renderSettings.lightDirection
+        renderSettings.fogColor = interpColors(la.fogColor, lb.fogColor, fade)
+        renderSettings.fogPreviewPosition = (
+            la.fogNear + int(float(lb.fogNear - la.fogNear) * fade),
+            la.fogFar  + int(float(lb.fogFar  - la.fogFar ) * fade),
+        )
 
 
 def update_lighting_space(renderSettings: "Fast64RenderSettings_Properties"):
@@ -161,20 +227,24 @@ class Fast64RenderSettings_Properties(bpy.types.PropertyGroup):
     ootSceneHeader: bpy.props.IntProperty(
         name="Header/Setup",
         description="Scene header / setup to use lighting data from.",
-        min=0, soft_max=10, default=0
+        min=0, soft_max=10, default=0,
+        update=on_update_oot_render_settings,
     )
     ootForceTimeOfDay: bpy.props.BoolProperty(
         name="Force Time of Day",
         description="Interpolate between four lights based on the time.",
-        default=False
+        default=False,
+        update=on_update_oot_render_settings,
     )
     ootLightIdx: bpy.props.IntProperty(
         name="Light Index",
-        min=0, soft_max=10, default=0
+        min=0, soft_max=10, default=0,
+        update=on_update_oot_render_settings,
     )
     ootTime: bpy.props.FloatProperty(
         name="Time of Day (Hours)",
         description="Time of day to emulate lighting conditions at, in hours.",
-        min=0.0, max=23.99, precision=2, subtype="TIME", unit="TIME"
+        min=0.0, max=23.99, default = 10.0, precision=2, subtype="TIME", unit="TIME",
+        update=on_update_oot_render_settings,
     )
     

--- a/fast64_internal/render_settings.py
+++ b/fast64_internal/render_settings.py
@@ -34,6 +34,7 @@ def on_update_oot_render_settings(self, context: bpy.types.Context):
         col0, dir0 = ootGetBaseOrCustomLight(l, 0, False, False)
         renderSettings.lightColor = tuple(c for c in col0)
         renderSettings.lightDirection = tuple(d for d in dir0)
+        # TODO: Implement light1 into shader nodes
         # col1, dir1 = ootGetBaseOrCustomLight(l, 1, False, False)
         # renderSettings.light1Color = tuple(c for c in col1)
         # renderSettings.light1Direction = tuple(d for d in dir1)

--- a/fast64_internal/render_settings.py
+++ b/fast64_internal/render_settings.py
@@ -226,13 +226,13 @@ class Fast64RenderSettings_Properties(bpy.types.PropertyGroup):
     )
     ootSceneHeader: bpy.props.IntProperty(
         name="Header/Setup",
-        description="Scene header / setup to use lighting data from.",
+        description="Scene header / setup to use lighting data from",
         min=0, soft_max=10, default=0,
         update=on_update_oot_render_settings,
     )
     ootForceTimeOfDay: bpy.props.BoolProperty(
         name="Force Time of Day",
-        description="Interpolate between four lights based on the time.",
+        description="Interpolate between four lights based on the time",
         default=False,
         update=on_update_oot_render_settings,
     )
@@ -243,7 +243,7 @@ class Fast64RenderSettings_Properties(bpy.types.PropertyGroup):
     )
     ootTime: bpy.props.FloatProperty(
         name="Time of Day (Hours)",
-        description="Time of day to emulate lighting conditions at, in hours.",
+        description="Time of day to emulate lighting conditions at, in hours",
         min=0.0, max=23.99, default = 10.0, precision=2, subtype="TIME", unit="TIME",
         update=on_update_oot_render_settings,
     )

--- a/fast64_internal/render_settings.py
+++ b/fast64_internal/render_settings.py
@@ -68,6 +68,7 @@ def on_update_oot_render_settings(self, context: bpy.types.Context):
         col0a, _ = ootGetBaseOrCustomLight(la, 0, False, False)
         col0b, _ = ootGetBaseOrCustomLight(lb, 0, False, False)
         renderSettings.lightColor = col0a + (col0b - col0a) * fade
+        # TODO: Implement light1 into shader nodes
         # col1a, _ = ootGetBaseOrCustomLight(la, 1, False, False)
         # col1b, _ = ootGetBaseOrCustomLight(lb, 1, False, False)
         # renderSettings.light1Color = col1a * fa + col1b * fb

--- a/fast64_internal/utility.py
+++ b/fast64_internal/utility.py
@@ -1160,6 +1160,10 @@ def gammaInverseValue(sRGBValue):
     return mathutils.Color((sRGBValue, sRGBValue, sRGBValue)).from_srgb_to_scene_linear().v
 
 
+def exportColor(lightColor):
+    return [scaleToU8(value) for value in gammaCorrect(lightColor)]
+
+
 def printBlenderMessage(msgSet, message, blenderOp):
     if blenderOp is not None:
         blenderOp.report(msgSet, message)
@@ -1267,6 +1271,15 @@ def writeEulerFloatToShort(command, offset, value):
     command[offset : offset + 2] = int(round(degrees(value))).to_bytes(2, "big", signed=True)
 
 
+def getObjDirectionVec(obj, toExport: bool):
+    rotation = getObjectQuaternion(obj)
+    if toExport:
+        spaceRot = mathutils.Euler((-pi / 2, 0, 0)).to_quaternion()
+        rotation = spaceRot @ rotation
+    normal = (rotation @ mathutils.Vector((0, 0, 1))).normalized()
+    return normal
+
+
 # convert 32 bit (8888) to 16 bit (5551) color
 def convert32to16bitRGBA(oldPixel):
     if oldPixel[3] > 127:
@@ -1332,6 +1345,13 @@ def convertFloatToFixed16(value):
     # value = min(max(value, -2**15), 2**15 - 1)
     # return int.from_bytes(
     # 	int(round(value)).to_bytes(2, 'big', signed = True), 'big')
+
+def scaleToU8(val):
+    return min(int(round(val * 0xFF)), 255)
+
+
+def normToSigned8Vector(normal):
+    return [int.from_bytes(int(value * 127).to_bytes(1, "big", signed=True), "big") for value in normal]
 
 
 # Normal values are signed bytes (-128 to 127)
@@ -1400,6 +1420,14 @@ def get_material_from_context(context: bpy.types.Context):
     except:
         return None
 
+
+def lightDataToObj(lightData):
+    for obj in bpy.context.scene.objects:
+        if obj.data == lightData:
+            return obj
+    raise PluginError("A material is referencing a light that is no longer in the scene (i.e. has been deleted).")
+
+
 def ootGetSceneOrRoomHeader(parent, idx, isRoom):
     # This should be in oot_utility.py, but it is needed in f3d_material.py
     # which creates a circular import. The real problem is that the F3D render
@@ -1423,3 +1451,26 @@ def ootGetSceneOrRoomHeader(parent, idx, isRoom):
         if idx - 4 >= len(altHeaders.cutsceneHeaders):
             return None
         return altHeaders.cutsceneHeaders[idx - 4]
+
+
+def ootGetBaseOrCustomLight(prop, idx, toExport: bool, errIfMissing: bool):
+    # This should be in oot_utility.py, but it is needed in render_settings.py
+    # which creates a circular import. The real problem is that the F3D render
+    # settings stuff should be in a place which can import both SM64 and OoT
+    # code without circular dependencies.
+    assert idx in {0, 1}
+    col = getattr(prop, "diffuse" + str(idx))
+    dir = (mathutils.Vector((1.0, 1.0, 1.0)) * (1.0 if idx == 0 else -1.0)).normalized()
+    if getattr(prop, "useCustomDiffuse" + str(idx)):
+        light = getattr(prop, "diffuse" + str(idx) + "Custom")
+        if light is None:
+            if errIfMissing:
+                raise PluginError("Error: Diffuse " + str(idx) + " light object not set in a scene lighting property.")
+            else:
+                col = light.color
+                lightObj = lightDataToObj(light)
+                dir = getObjDirectionVec(lightObj, toExport)
+    col = mathutils.Vector(tuple(c for c in col))
+    if toExport:
+        col, dir = exportColor(col), normToSigned8Vector(dir)
+    return col, dir

--- a/fast64_internal/utility.py
+++ b/fast64_internal/utility.py
@@ -1346,6 +1346,7 @@ def convertFloatToFixed16(value):
     # return int.from_bytes(
     # 	int(round(value)).to_bytes(2, 'big', signed = True), 'big')
 
+
 def scaleToU8(val):
     return min(int(round(val * 0xFF)), 255)
 

--- a/fast64_internal/utility.py
+++ b/fast64_internal/utility.py
@@ -1399,3 +1399,27 @@ def get_material_from_context(context: bpy.types.Context):
         return context.material_slot.material
     except:
         return None
+
+def ootGetSceneOrRoomHeader(parent, idx, isRoom):
+    # This should be in oot_utility.py, but it is needed in f3d_material.py
+    # which creates a circular import. The real problem is that the F3D render
+    # settings stuff should be in a place which can import both SM64 and OoT
+    # code without circular dependencies.
+    if idx < 0:
+        raise PluginError("Alternate scene/room header index too low: " + str(idx))
+    target = "Room" if isRoom else "Scene"
+    altHeaders = getattr(parent, "ootAlternate" + target + "Headers")
+    if idx == 0:
+        return getattr(parent, "oot" + target + "Header")
+    elif 1 <= idx <= 3:
+        if idx == 1:
+            ret = altHeaders.childNightHeader
+        elif idx == 2:
+            ret = altHeaders.adultDayHeader
+        else:
+            ret = altHeaders.adultNightHeader
+        return None if ret.usePreviousHeader else ret
+    else:
+        if idx - 4 >= len(altHeaders.cutsceneHeaders):
+            return None
+        return altHeaders.cutsceneHeaders[idx - 4]


### PR DESCRIPTION
Connects OoT scene header lighting settings to the V5 render settings preview. For scenes with time of day lighting, this includes emulation of the lighting interpolation used in OoT, so the user can easily drag a slider and watch the lighting change over the day.